### PR TITLE
Issue #1 - Make tripal 3 compatible

### DIFF
--- a/kp_frontpage.module
+++ b/kp_frontpage.module
@@ -50,7 +50,7 @@ function kptheme_preprocess_page(&$vars, $hook) {
       'main_slideshow_view'     => 'kp_frontpage_main_slideshow',
       'copy_crops_view'         => 'uofs_crop_species',
       'footer_project_view'     => 'kp_homepage_footer_project_slideshow_view',
-      'footer_publication_view' => 'kp_homepage_footer_publication_slideshow_view'
+      'footer_publication_view' => 'kp_frontpage_footer_publication_slideshow_tripal_3'
     );
 
     foreach($arr_views as $i => $view) {

--- a/templates/page--front.tpl.php
+++ b/templates/page--front.tpl.php
@@ -51,7 +51,7 @@ $module_path = drupal_get_path('module','kp_frontpage');
       ?>
     </div>
 
-<1--
+<!--
     <?php if ($variables['is_front'] === TRUE): ?>
      <div id="container-control-panel" style="display: none;">
        <div class="container-panel">
@@ -285,7 +285,7 @@ $module_path = drupal_get_path('module','kp_frontpage');
                   <div class="info-col slide-info">
                     <h2 class="section-title">&#9632; Publications:</h2>
                     <a href="<?php print url('research/publications')?>" class="context-link">&raquo; More Publications</a>
-                    <?php print views_embed_view('kp_homepage_footer_publication_slideshow_view', 'default'); ?>
+                    <?php print views_embed_view('kp_frontpage_footer_publication_slideshow_tripal_3', 'default'); ?>
                   </div>
                   <div class="info-col chevron-right"><span>&rang;</span></div>
                   <div class="clear-no-height">&nbsp;</div>

--- a/views/kp_homepage_footer_publication_slideshow_view.view
+++ b/views/kp_homepage_footer_publication_slideshow_view.view
@@ -7,18 +7,18 @@
  */
 
 $view = new view();
-$view->name = 'kp_homepage_footer_publication_slideshow_view';
-$view->description = 'A slideshow of chado publications for the homepage.';
-$view->tag = 'KP Homepage';
-$view->base_table = 'pub';
-$view->human_name = 'KP Homepage: Footer Publication Slideshow';
+$view->name = 'kp_frontpage_footer_publication_slideshow_tripal_3';
+$view->description = '';
+$view->tag = 'default';
+$view->base_table = 'TPUB__0000002';
+$view->human_name = 'KP Frontpage Footer Publication Slideshow Tripal 3';
 $view->core = 7;
 $view->api_version = '3.0';
 $view->disabled = FALSE; /* Edit this to true to make a default view disabled initially */
 
 /* Display: Master */
 $handler = $view->new_display('default', 'Master', 'default');
-$handler->display->display_options['title'] = 'Publications';
+$handler->display->display_options['title'] = 'KP Frontpage Footer Publication Slideshow Tripal 3';
 $handler->display->display_options['use_more_always'] = FALSE;
 $handler->display->display_options['access']['type'] = 'none';
 $handler->display->display_options['cache']['type'] = 'none';
@@ -34,75 +34,28 @@ $handler->display->display_options['style_options']['row_class_special'] = FALSE
 $handler->display->display_options['style_options']['wrapper_class'] = '';
 $handler->display->display_options['row_plugin'] = 'fields';
 $handler->display->display_options['row_options']['default_field_elements'] = FALSE;
-/* No results behavior: Global: Text area */
-$handler->display->display_options['empty']['area']['id'] = 'area';
-$handler->display->display_options['empty']['area']['table'] = 'views';
-$handler->display->display_options['empty']['area']['field'] = 'area';
-$handler->display->display_options['empty']['area']['label'] = 'Warning: No nodes';
-$handler->display->display_options['empty']['area']['empty'] = TRUE;
-$handler->display->display_options['empty']['area']['content'] = '<div class="messages warning">
-This slideshow displays Tripal <em>Publication</em> nodes. Please add at least one such page to get rid of this message.
-</div>';
-$handler->display->display_options['empty']['area']['format'] = 'full_html';
-/* Relationship: Chado Pub: pub_id => Pubprop (pub_id) */
-$handler->display->display_options['relationships']['pub_id_to_pubprop']['id'] = 'pub_id_to_pubprop';
-$handler->display->display_options['relationships']['pub_id_to_pubprop']['table'] = 'pub';
-$handler->display->display_options['relationships']['pub_id_to_pubprop']['field'] = 'pub_id_to_pubprop';
-$handler->display->display_options['relationships']['pub_id_to_pubprop']['label'] = 'PubProp Authors';
-/* Field: Content: Nid */
-$handler->display->display_options['fields']['nid']['id'] = 'nid';
-$handler->display->display_options['fields']['nid']['table'] = 'node';
-$handler->display->display_options['fields']['nid']['field'] = 'nid';
-$handler->display->display_options['fields']['nid']['label'] = '';
-$handler->display->display_options['fields']['nid']['exclude'] = TRUE;
-$handler->display->display_options['fields']['nid']['element_label_colon'] = FALSE;
-/* Field: Chado Pub: Pub Id */
-$handler->display->display_options['fields']['pub_id']['id'] = 'pub_id';
-$handler->display->display_options['fields']['pub_id']['table'] = 'pub';
-$handler->display->display_options['fields']['pub_id']['field'] = 'pub_id';
-$handler->display->display_options['fields']['pub_id']['label'] = '';
-$handler->display->display_options['fields']['pub_id']['exclude'] = TRUE;
-$handler->display->display_options['fields']['pub_id']['element_label_colon'] = FALSE;
-/* Field: Chado Pub: Pyear */
-$handler->display->display_options['fields']['pyear']['id'] = 'pyear';
-$handler->display->display_options['fields']['pyear']['table'] = 'pub';
-$handler->display->display_options['fields']['pyear']['field'] = 'pyear';
-$handler->display->display_options['fields']['pyear']['label'] = '';
-$handler->display->display_options['fields']['pyear']['exclude'] = TRUE;
-$handler->display->display_options['fields']['pyear']['element_label_colon'] = FALSE;
-/* Field: Chado Pub: Title */
-$handler->display->display_options['fields']['title']['id'] = 'title';
-$handler->display->display_options['fields']['title']['table'] = 'pub';
-$handler->display->display_options['fields']['title']['field'] = 'title';
-$handler->display->display_options['fields']['title']['label'] = '';
-$handler->display->display_options['fields']['title']['alter']['make_link'] = TRUE;
-$handler->display->display_options['fields']['title']['alter']['path'] = 'node/[nid]';
-$handler->display->display_options['fields']['title']['element_type'] = 'h2';
-$handler->display->display_options['fields']['title']['element_label_colon'] = FALSE;
-$handler->display->display_options['fields']['title']['element_default_classes'] = FALSE;
-/* Field: Chado Pubprop: Value */
-$handler->display->display_options['fields']['value']['id'] = 'value';
-$handler->display->display_options['fields']['value']['table'] = 'pubprop';
-$handler->display->display_options['fields']['value']['field'] = 'value';
-$handler->display->display_options['fields']['value']['relationship'] = 'pub_id_to_pubprop';
-$handler->display->display_options['fields']['value']['label'] = '';
-$handler->display->display_options['fields']['value']['alter']['alter_text'] = TRUE;
-$handler->display->display_options['fields']['value']['alter']['text'] = '[value] <a href="pub/[pub_id]">More Information</a>';
-$handler->display->display_options['fields']['value']['alter']['max_length'] = '160';
-$handler->display->display_options['fields']['value']['alter']['more_link'] = TRUE;
-$handler->display->display_options['fields']['value']['alter']['more_link_text'] = 'More Information';
-$handler->display->display_options['fields']['value']['alter']['more_link_path'] = 'node/[nid]';
-$handler->display->display_options['fields']['value']['element_type'] = 'p';
-$handler->display->display_options['fields']['value']['element_label_colon'] = FALSE;
-$handler->display->display_options['fields']['value']['element_default_classes'] = FALSE;
-/* Sort criterion: Chado Pub: Pyear */
-$handler->display->display_options['sorts']['pyear']['id'] = 'pyear';
-$handler->display->display_options['sorts']['pyear']['table'] = 'pub';
-$handler->display->display_options['sorts']['pyear']['field'] = 'pyear';
-$handler->display->display_options['sorts']['pyear']['order'] = 'DESC';
-/* Filter criterion: Chado Cvterm: Name */
-$handler->display->display_options['filters']['name']['id'] = 'name';
-$handler->display->display_options['filters']['name']['table'] = 'cvterm';
-$handler->display->display_options['filters']['name']['field'] = 'name';
-$handler->display->display_options['filters']['name']['relationship'] = 'pub_id_to_pubprop';
-$handler->display->display_options['filters']['name']['value'] = 'Authors';
+/* Field: Publication: Citation */
+$handler->display->display_options['fields']['tpub__citation']['id'] = 'tpub__citation';
+$handler->display->display_options['fields']['tpub__citation']['table'] = 'TPUB__0000002';
+$handler->display->display_options['fields']['tpub__citation']['field'] = 'tpub__citation';
+$handler->display->display_options['fields']['tpub__citation']['label'] = '';
+$handler->display->display_options['fields']['tpub__citation']['element_type'] = 'p';
+$handler->display->display_options['fields']['tpub__citation']['element_label_colon'] = FALSE;
+$handler->display->display_options['fields']['tpub__citation']['element_default_classes'] = FALSE;
+/* Field: Publication: Entity ID */
+$handler->display->display_options['fields']['entity_id']['id'] = 'entity_id';
+$handler->display->display_options['fields']['entity_id']['table'] = 'TPUB__0000002';
+$handler->display->display_options['fields']['entity_id']['field'] = 'entity_id';
+$handler->display->display_options['fields']['entity_id']['label'] = '';
+$handler->display->display_options['fields']['entity_id']['alter']['alter_text'] = TRUE;
+$handler->display->display_options['fields']['entity_id']['alter']['text'] = '<a href="Publication/[entity_id]">More Information</a>';
+$handler->display->display_options['fields']['entity_id']['element_label_colon'] = FALSE;
+/* Sort criterion: Publication: Publication Year */
+$handler->display->display_options['sorts']['tpub__year']['id'] = 'tpub__year';
+$handler->display->display_options['sorts']['tpub__year']['table'] = 'TPUB__0000002';
+$handler->display->display_options['sorts']['tpub__year']['field'] = 'tpub__year';
+$handler->display->display_options['sorts']['tpub__year']['order'] = 'DESC';
+
+/* Display: Page */
+$handler = $view->new_display('page', 'Page', 'page');
+$handler->display->display_options['path'] = 'kp-frontpage-footer-publication-slideshow-tripal-3';


### PR DESCRIPTION
Update footer publication slideshow to Tripal 3 Compatible. It uses field: citation that contains author, title and year information instead of using field: author and field: title separately. This is due to some fields in views, including title and author return empty.

Layout of every slideshow show citation information (authors, title and year) in a paragraph form followed by a more information link. In Tripal 2 version, The title is a link followed by authors and more information link.

NOTE: update layout when title and author fields in views become available to match over all layout of slideshow in frontpage.
