### PR TITLE
Layout and other issues

### DIFF
--- a/js/kp_frontpage.js
+++ b/js/kp_frontpage.js
@@ -37,12 +37,6 @@
         }
       });
 
-      $('body').click(function() {
-        if ($('.kpfrontpage-popupwindow')) {
-          $('.kpfrontpage-popupwindow').fadeOut(300);
-        }
-      });
-
       // Delay events from firing so as not to become overly sensitive.
       var d;
 

--- a/js/kp_frontpage.js
+++ b/js/kp_frontpage.js
@@ -26,11 +26,20 @@
       $('.kpfrontpage-link-slide a').click(function(e) {
         e.preventDefault();
         // Stop scroll just about where the DATA heading is.
-        var stopAt = $('#kpfrontpage-copy-explore-data-data');
+        // When page is reduced, make the link go to specific data section.
+        var contentWrapper = $('#kpfrontpage-copy').width();
+        var stopAt = (contentWrapper == 850) ? $('#data-' + e.target.id) : $('#kpfrontpage-copy-explore-data-data');
+
         if (stopAt.length) {
           $('html, body').stop().animate({
-            scrollTop: (stopAt.offset().top - 200)
+            scrollTop: (stopAt.offset().top)
           }, 700);
+        }
+      });
+
+      $('body').click(function() {
+        if ($('.kpfrontpage-popupwindow')) {
+          $('.kpfrontpage-popupwindow').fadeOut(300);
         }
       });
 

--- a/kp_frontpage.css
+++ b/kp_frontpage.css
@@ -119,6 +119,29 @@ a.kpfrontpage-navigation-white {
   }
 
 
+/* /////// HIGHLIGHT */
+#highlighted {
+  background-color: #FDFFD6;
+  border-bottom: 2px solid #FF0000 !important;
+  color: #000000;
+  font-family: sans-serif;
+  font-size: 1.0em;
+}
+
+  #highlighted > div {
+    margin: 0 auto;
+    padding: 8px 0;
+    width: 1280px;
+  }
+
+  #highlighted div > span {
+    color: #FF0000;
+    font-weight: bold;
+    margin: 0;
+    padding: 0;
+    text-transform: uppercase;
+  }
+
 /* /////// POP UP/DROP MENU/WINDOW */
 .kpfrontpage-popupwindow-element {
   cursor: pointer;
@@ -178,7 +201,7 @@ a.kpfrontpage-navigation-white {
 #kpfrontpage-content-wrapper {
   margin: 0 auto;
   position: inherit;
-  width: 1280px;
+  max-width: 1280px;
 }
 
 #kpfrontpage-userpanel {
@@ -666,7 +689,7 @@ a.kpfrontpage-navigation-white {
 /* //////////////////////////////////////////////// */
 
 
-/* Media query - apply stype when viewport is 1400px */
+/* Media query - apply stype when viewport is 1300px */
 @media(max-width: 1300px) {
   #kpfrontpage-page-wrapper {
     margin: 0 auto;
@@ -679,6 +702,10 @@ a.kpfrontpage-navigation-white {
 
   #kpfrontpage-copy {
     width: 850px;
+  }
+
+  #highlighted > div {
+    width: 900px;
   }
 
   #kpfrontpage-copy-quickstart {

--- a/kp_frontpage.css
+++ b/kp_frontpage.css
@@ -122,25 +122,26 @@ a.kpfrontpage-navigation-white {
 /* /////// HIGHLIGHT */
 #highlighted {
   background-color: #FDFFD6;
-  border-bottom: 2px solid #FF0000 !important;
+  border-bottom: 2px solid #FF0000;
   color: #000000;
   font-family: sans-serif;
-  font-size: 1.0em;
 }
 
   #higlighted-content-main-page {
+    font-size: 0.9em;
     margin: 0 auto;
     padding: 8px 0;
     width: 1280px;
   }
 
-  #higlighted-content-main-page > span {
-    color: #FF0000;
-    font-weight: bold;
+  #higlighted-content-main-page p,
+  #higlighted-content-main-page h2,
+  #higlighted-content-main-page div {
     margin: 0;
     padding: 0;
-    text-transform: uppercase;
+    border: none;
   }
+
 
 /* /////// POP UP/DROP MENU/WINDOW */
 .kpfrontpage-popupwindow-element {
@@ -693,6 +694,10 @@ a.kpfrontpage-navigation-white {
 @media(max-width: 1300px) {
   #kpfrontpage-page-wrapper {
     margin: 0 auto;
+  }
+
+  #kpfrontpage-userpanel {
+    font-size: 0.9em;
   }
 
   #kpfrontpage-header {

--- a/kp_frontpage.css
+++ b/kp_frontpage.css
@@ -128,13 +128,13 @@ a.kpfrontpage-navigation-white {
   font-size: 1.0em;
 }
 
-  #highlighted > div {
+  #higlighted-content-main-page {
     margin: 0 auto;
     padding: 8px 0;
     width: 1280px;
   }
 
-  #highlighted div > span {
+  #higlighted-content-main-page > span {
     color: #FF0000;
     font-weight: bold;
     margin: 0;

--- a/templates/page--front.tpl.php
+++ b/templates/page--front.tpl.php
@@ -8,7 +8,9 @@
 <div id="page-wrapper">
  <?php if ($page['highlighted'] || $_SERVER['HTTP_HOST'] == 'localhost') { ?>
  <div id="highlighted">
-   <div id="higlighted-content-main-page"><?php print ($_SERVER['HTTP_HOST'] == 'localhost') ? '<span>This is a clone of KnowPulse</span>' : render($page['highlighted']); ?></div>
+   <div id="higlighted-content-main-page">
+     <?php print ($page['highlighted']) ? render($page['highlighted']) : 'This is a KnowPulse Clone.'; ?>
+   </div>
  </div>
 <?php } ?>
 
@@ -35,7 +37,12 @@
                  </div>
                </li>
                <li><a href="<?php print $path_host. '/node/add/kp-frontpage-cms'; ?>" class="kpfrontpage-navigation-white" title="Explore KnowPulse: Add news, updates and upcoming events.">Add News & Events</a></li>
-               <li><a href="<?php print $path_host. '/tripal_hq/admin'; ?>" class="kpfrontpage-navigation-white" title="Explore KnowPulse: Add Biological Content.">Add Biological Content</a></li>
+               <li><a href="<?php print $path_host. '/tripal_hq/bio_data'; ?>" class="kpfrontpage-navigation-white" title="Explore KnowPulse: Add Biological Content.">Add Biological Content</a></li>
+
+               <?php if (user_access('administer site configuration')) { ?>
+               <li><a href="<?php print $path_host. '/tripal_hq/admin'; ?>" class="kpfrontpage-navigation-white" title="Explore KnowPulse: Approve Biological Content.">Approve Data</a></li>
+               <?php } ?>
+
                <li><a href="<?php print $path_host . '/user/logout'; ?>" class="kpfrontpage-navigation-white" title="Explore KnowPulse: Sign out.">Logout</a></li>
 
                <?php

--- a/templates/page--front.tpl.php
+++ b/templates/page--front.tpl.php
@@ -6,6 +6,12 @@
 ?>
 
 <div id="page-wrapper">
+ <?php if ($page['highlighted'] || $_SERVER['HTTP_HOST'] == 'localhosts') { ?>
+ <div id="highlighted">
+   <div><?php print ($_SERVER['HTTP_HOST'] == 'localhost') ? '<span>This is a clone of KnowPulse</span>' : render($page['highlighted']); ?></div>
+ </div>
+<?php } ?>
+
   <div id="page">
     <div id="kpfrontpage-page-wrapper">
        <div id="kpfrontpage-content-wrapper">
@@ -29,7 +35,7 @@
                  </div>
                </li>
                <li><a href="<?php print $path_host. '/node/add/kp-frontpage-cms'; ?>" class="kpfrontpage-navigation-white" title="Explore KnowPulse: Add news, updates and upcoming events.">Add News & Events</a></li>
-               <li><a href="<?php print $path_host. '/admin/content/bio_data/add'; ?>" class="kpfrontpage-navigation-white" title="Explore KnowPulse: Add Biological Content.">Add Biological Content</a></li>
+               <li><a href="<?php print $path_host. '/tripal_hq/admin'; ?>" class="kpfrontpage-navigation-white" title="Explore KnowPulse: Add Biological Content.">Add Biological Content</a></li>
                <li><a href="<?php print $path_host . '/user/logout'; ?>" class="kpfrontpage-navigation-white" title="Explore KnowPulse: Sign out.">Logout</a></li>
 
                <?php
@@ -86,9 +92,9 @@
 
              <div class="kpfrontpage-element-right" title="Data in KnowPulse: Phenotypes, Genotypes and Germplasm">
                <ul class="kpfrontpage-horizontal-list kpfrontpage-link-slide">
-                 <li><a href="#" title="Data - Phenotypes.">Phenotypes</a></li>
-                 <li><a href="#" title="Data - Genotypes.">Genotypes</a></li>
-                 <li><a href="#" title="Data - Germplasm.">Germplasm</a></li>
+                 <li><a id="go-phenotypes" href="#" title="Data - Phenotypes.">Phenotypes</a></li>
+                 <li><a id="go-genotypes" href="#" title="Data - Genotypes.">Genotypes</a></li>
+                 <li><a id="go-germplasm" href="#" title="Data - Germplasm.">Germplasm</a></li>
                </ul>
              </div>
              <div class="kpfrontpage-clearfloat">&nbsp;</div>
@@ -134,7 +140,7 @@
                <h1 class="kpfrontpage-data-header"><span class="kpfrontpage-text-italic">Data</span></h1>
                <div>
                  <div>
-                   <div class="kpfrontpage-copy-explore-data-data-summary-count kpfrontpage-bg-diagonallines" title="<?php print $data_stats['Phenotypes']['long_value']; ?>">
+                   <div id ="data-go-phenotypes" class="kpfrontpage-copy-explore-data-data-summary-count kpfrontpage-bg-diagonallines" title="<?php print $data_stats['Phenotypes']['long_value']; ?>">
                      <span><?php print $data_stats['Phenotypes']['short_value']; ?></span> Phenotypes
                    </div>
                    <h2><img src="<?php print $path_images . 'infographics/infographics-data.gif'; ?>" align="absmiddle" /> Phenotypic Data</h2>
@@ -165,7 +171,7 @@
                    ?>
                  </div>
                  <div>
-                   <div class="kpfrontpage-copy-explore-data-data-summary-count kpfrontpage-bg-diagonallines" title="<?php print $data_stats['Genotype Calls']['long_value']; ?>">
+                   <div id="data-go-genotypes" class="kpfrontpage-copy-explore-data-data-summary-count kpfrontpage-bg-diagonallines" title="<?php print $data_stats['Genotype Calls']['long_value']; ?>">
                      <span><?php print $data_stats['Genotype Calls']['short_value']; ?></span> Genotype Calls
                    </div>
                    <h2><img src="<?php print $path_images . 'infographics/infographics-data.gif'; ?>" align="absmiddle" /> Genomic Data</h2>
@@ -195,7 +201,7 @@
                    <div class="kpfrontpage-clearfloat">&nbsp;</div>
                  </div>
                  <div>
-                   <div class="kpfrontpage-copy-explore-data-data-summary-count kpfrontpage-bg-diagonallines" title="<?php print $data_stats['Germplasm']['long_value']; ?>">
+                   <div id="data-go-germplasm" class="kpfrontpage-copy-explore-data-data-summary-count kpfrontpage-bg-diagonallines" title="<?php print $data_stats['Germplasm']['long_value']; ?>">
                      <span><?php print $data_stats['Germplasm']['short_value']; ?></span> Germplasm
                    </div>
                    <h2><img src="<?php print $path_images . 'infographics/infographics-data.gif'; ?>" align="absmiddle" /> Germplasm</h2>

--- a/templates/page--front.tpl.php
+++ b/templates/page--front.tpl.php
@@ -8,7 +8,7 @@
 <div id="page-wrapper">
  <?php if ($page['highlighted'] || $_SERVER['HTTP_HOST'] == 'localhost') { ?>
  <div id="highlighted">
-   <div><?php print ($_SERVER['HTTP_HOST'] == 'localhost') ? '<span>This is a clone of KnowPulse</span>' : render($page['highlighted']); ?></div>
+   <div id="higlighted-content-main-page"><?php print ($_SERVER['HTTP_HOST'] == 'localhost') ? '<span>This is a clone of KnowPulse</span>' : render($page['highlighted']); ?></div>
  </div>
 <?php } ?>
 

--- a/templates/page--front.tpl.php
+++ b/templates/page--front.tpl.php
@@ -6,7 +6,7 @@
 ?>
 
 <div id="page-wrapper">
- <?php if ($page['highlighted'] || $_SERVER['HTTP_HOST'] == 'localhosts') { ?>
+ <?php if ($page['highlighted'] || $_SERVER['HTTP_HOST'] == 'localhost') { ?>
  <div id="highlighted">
    <div><?php print ($_SERVER['HTTP_HOST'] == 'localhost') ? '<span>This is a clone of KnowPulse</span>' : render($page['highlighted']); ?></div>
  </div>


### PR DESCRIPTION
This PR will fix the following issues.
- Layout not centered resizing the window.
- Jump menu scroll down is off the content.
- Drop down menu stays until you select the element.
- Replace Add bio data to Tripal HQ.

Additional features now support notification area both displayed in main page and sub pages.

Dependencies:
This is dependent on KP Theme updates.

To test:
1. Layout - resize window while viewing homepage, layout should stay center.
2. Jump Menu - Resize window and click the quick navigation to data. Each item should scroll to the corresponding data section when clicked.
3. Notification area - On your localhost, it will display 'This is a clone of KnowPulse' while on the server any message placed in `highligted` block should appear in both main and sub pages.

Important to note: I recommend the message not to contain any markup other than <span>, which will render all caps and red colour. This may be used to style first few words of the message to indicate relevance.
